### PR TITLE
find-proxy-maintainers: handle multiline descriptions

### DIFF
--- a/find-proxy-users.py
+++ b/find-proxy-users.py
@@ -80,7 +80,7 @@ def readMetadata(meta_file: str, maintainers: dict, add_desc: bool = False) -> N
         # address to be the proxy user
         if 'gentoo.org' not in mail:
             try:
-                desc = maintainer.find('description').text
+                desc = maintainer.find('description').text.replace('\n', ' ')
             except AttributeError:
                 desc = ''
             try:


### PR DESCRIPTION
Replace newline characters in multiline description text.

Signed-off-by: Gokturk Yuksek gokturk@binghamton.edu
